### PR TITLE
feat: add notice and dev support fields

### DIFF
--- a/DalamudPackager/DalamudPackager.cs
+++ b/DalamudPackager/DalamudPackager.cs
@@ -376,6 +376,21 @@ namespace DalamudPackager {
         /// </summary>
         public string? Changelog { get; set; }
 
+        /// <summary>
+        /// Gets notice/warning to display for plugin (can be used where there is an issue but not ban worthy).
+        /// </summary>
+        public string? Notice { get; set; }
+
+        /// <summary>
+        /// Gets or sets developer support state.
+        /// </summary>
+        public int? DevSupportState { get; set; } = 0;
+
+        /// <summary>
+        /// Gets or sets reason / comment for the current developer state.
+        /// </summary>
+        public string? DevSupportStateReason { get; set; }
+        
         internal bool LogMissing(TaskLoggingHelper log) {
             var anyNull = this.Name == null || this.Author == null || this.Description == null || this.Punchline == null;
 

--- a/DalamudPackager/DalamudPackager.csproj
+++ b/DalamudPackager/DalamudPackager.csproj
@@ -14,7 +14,7 @@
         <Title>DalamudPackager</Title>
         <Description>An MSBuild task that simplifies making Dalamud plugins by generating a manifest and packing the build output into a release-ready zip.</Description>
         <PackageLicenseExpression>EUPL-1.2</PackageLicenseExpression>
-        <Version>2.1.7</Version>
+        <Version>2.1.8</Version>
         <Authors>Anna Clemens</Authors>
         <PackageProjectUrl>https://github.com/goatcorp/DalamudPackager</PackageProjectUrl>
         <RepositoryUrl>https://github.com/goatcorp/DalamudPackager</RepositoryUrl>

--- a/README.org
+++ b/README.org
@@ -70,7 +70,11 @@ following JSON file in your output directory.
   // this will be set to 2 automatically
   "DalamudApiLevel": 2,
   // this will be set to 0 automatically
-  "LoadPriority": 0
+  "LoadPriority": 0,
+  // these following statuses should only be filled out in special cases
+  "Notice": "Warning, you better backup!",
+  "DevSupportState": "2",
+  "DevSupportStateReason": "Need a new dev!",
 }
 #+end_src
 


### PR DESCRIPTION
Add new optional support state and notice fields. These will probably be usually set at assets level but this allows dev to as well.