### PR TITLE
Bump version for API 7

### DIFF
--- a/DalamudPackager/DalamudPackager.cs
+++ b/DalamudPackager/DalamudPackager.cs
@@ -349,7 +349,7 @@ namespace DalamudPackager {
         /// <summary>
         /// The API level of this plugin.
         /// </summary>
-        public int DalamudApiLevel { get; set; } = 6;
+        public int DalamudApiLevel { get; set; } = 7;
 
         /// <summary>
         /// Load priority for this plugin. Higher values means higher priority. 0 is default priority.

--- a/DalamudPackager/DalamudPackager.csproj
+++ b/DalamudPackager/DalamudPackager.csproj
@@ -14,7 +14,7 @@
         <Title>DalamudPackager</Title>
         <Description>An MSBuild task that simplifies making Dalamud plugins by generating a manifest and packing the build output into a release-ready zip.</Description>
         <PackageLicenseExpression>EUPL-1.2</PackageLicenseExpression>
-        <Version>2.1.7</Version>
+        <Version>2.1.8</Version>
         <Authors>Anna Clemens</Authors>
         <PackageProjectUrl>https://github.com/goatcorp/DalamudPackager</PackageProjectUrl>
         <RepositoryUrl>https://github.com/goatcorp/DalamudPackager</RepositoryUrl>


### PR DESCRIPTION
If published to NuGet, lets devs update their plugins early without having to manually specify API level.