### PR TITLE
Add Feedback related manifest fields

### DIFF
--- a/DalamudPackager/DalamudPackager.cs
+++ b/DalamudPackager/DalamudPackager.cs
@@ -390,6 +390,16 @@ namespace DalamudPackager {
         /// </summary>
         public string? Changelog { get; set; }
 
+        /// <summary>
+        /// Gets a value indicating whether this plugin accepts feedback.
+        /// </summary>
+        public bool AcceptsFeedback { get; set; } = true;
+
+        /// <summary>
+        /// Gets a message that is shown to users when sending feedback.
+        /// </summary>
+        public string? FeedbackMessage { get; set; }
+
         internal bool LogMissing(TaskLoggingHelper log) {
             var anyNull = this.Name == null || this.Author == null || this.Description == null || this.Punchline == null;
 

--- a/DalamudPackager/DalamudPackager.csproj
+++ b/DalamudPackager/DalamudPackager.csproj
@@ -14,7 +14,7 @@
         <Title>DalamudPackager</Title>
         <Description>An MSBuild task that simplifies making Dalamud plugins by generating a manifest and packing the build output into a release-ready zip.</Description>
         <PackageLicenseExpression>EUPL-1.2</PackageLicenseExpression>
-        <Version>2.1.8</Version>
+        <Version>2.1.9</Version>
         <Authors>Anna Clemens</Authors>
         <PackageProjectUrl>https://github.com/goatcorp/DalamudPackager</PackageProjectUrl>
         <RepositoryUrl>https://github.com/goatcorp/DalamudPackager</RepositoryUrl>


### PR DESCRIPTION
This should make sure that DalamudPackager doesn't strip these values off, especially for plugins that don't want to enable the feedback display.
