### PR TITLE
Support manifest properties defined in .csproj

### DIFF
--- a/DalamudPackager/build/DalamudPackager.targets
+++ b/DalamudPackager/build/DalamudPackager.targets
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
         <PackagerTargetFile>$(ProjectDir)DalamudPackager.targets</PackagerTargetFile>
@@ -6,21 +6,49 @@
 
     <Import Project="$(PackagerTargetFile)" Condition="Exists('$(PackagerTargetFile)')"/>
 
-    <Target Name="DefaultDalamudPackagerDebug"
-            AfterTargets="Build"
-            Condition="'$(Configuration)' == 'Debug' and !Exists('$(PackagerTargetFile)')">
+    <Target Name="RunDalamudPackager">
         <DalamudPackager ProjectDir="$(ProjectDir)"
                          OutputPath="$(OutputPath)"
                          AssemblyName="$(AssemblyName)"
-                         MakeZip="false"/>
+                         MakeZip="$(MakeZip)"
+                         Author="$(Author)"
+                         Name="$(Name)"
+                         InternalName="$(InternalName)"
+                         AssemblyVersion="$(AssemblyVersion)"
+                         MinimumDalamudVersion="$(MinimumDalamudVersion)"
+                         Punchline="$(Punchline)"
+                         Description="$(Description)"
+                         ApplicableVersion="$(ApplicableVersion)"
+                         RepoUrl="$(RepoUrl)"
+                         Tags="$(Tags)"
+                         CategoryTags="$(CategoryTags)"
+                         DalamudApiLevel="$(DalamudApiLevel)"
+                         LoadRequiredState="$(LoadRequiredState)"
+                         LoadSync="$(LoadSync)"
+                         CanUnloadAsync="$(CanUnloadAsync)"
+                         LoadPriority="$(LoadPriority)"
+                         ImageUrls="$(ImageUrls)"
+                         IconUrl="$(IconUrl)"
+                         Changelog="$(Changelog)"
+                         AcceptsFeedback="$(AcceptsFeedback)"
+                         FeedbackMessage="$(FeedbackMessage)" />
+    </Target>
+
+    <Target Name="DefaultDalamudPackagerDebug"
+            AfterTargets="Build"
+            Condition="'$(Configuration)' == 'Debug' and !Exists('$(PackagerTargetFile)')">
+        <PropertyGroup>
+            <MakeZip>false</MakeZip>
+        </PropertyGroup>
+        <CallTarget Targets="RunDalamudPackager" />
     </Target>
 
     <Target Name="DefaultDalamudPackagerRelease"
             AfterTargets="Build"
             Condition="'$(Configuration)' == 'Release' and !Exists('$(PackagerTargetFile)')">
-        <DalamudPackager ProjectDir="$(ProjectDir)"
-                         OutputPath="$(OutputPath)"
-                         AssemblyName="$(AssemblyName)"
-                         MakeZip="true"/>
+        <PropertyGroup>
+            <MakeZip>true</MakeZip>
+        </PropertyGroup>
+        <CallTarget Targets="RunDalamudPackager" />
     </Target>
 </Project>


### PR DESCRIPTION
This allows manifest properties to be defined in the .csproj, removing the need of an extra manifest json/yaml file.
The properties in the .csproj are optional, but if given, they will override existing values coming from the manifest file.

```xml
<PropertyGroup>
    <Author>your name here</Author>
    <Name>Sample Plugin</Name>
    <InternalName>SamplePlugin</InternalName>
    <AssemblyVersion>1.0.0.0</AssemblyVersion>
    <MinimumDalamudVersion>13.0.0</MinimumDalamudVersion>
    <Punchline>A short one-liner that shows up in /xlplugins.</Punchline>
    <Description>A description that shows up in /xlplugins. List any major slash-command(s).</Description>
    <ApplicableVersion>2025.10.30.0000.0000</ApplicableVersion>
    <RepoUrl>https://github.com/goatcorp/SamplePlugin</RepoUrl>
    <Tags>sample;plugin;goats</Tags>
    <CategoryTags>debug;test</CategoryTags>
    <DalamudApiLevel>14</DalamudApiLevel>
    <LoadRequiredState>1</LoadRequiredState>
    <LoadSync>true</LoadSync>
    <CanUnloadAsync>true</CanUnloadAsync>
    <LoadPriority>1</LoadPriority>
    <ImageUrls>https://raw.githubusercontent.com/goatcorp/DalamudPluginsD17/refs/heads/main/stable/SamplePlugin/images/image1.png;https://raw.githubusercontent.com/goatcorp/DalamudPluginsD17/refs/heads/main/stable/SamplePlugin/images/image2.png</ImageUrls>
    <IconUrl>https://raw.githubusercontent.com/goatcorp/DalamudPluginsD17/refs/heads/main/stable/SamplePlugin/images/icon.png</IconUrl>
    <Changelog>CHANGES!</Changelog>
    <AcceptsFeedback>true</AcceptsFeedback>
    <FeedbackMessage>Be nice.</FeedbackMessage>
</PropertyGroup>
```